### PR TITLE
fix: removes webpack cache errors

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -2,6 +2,9 @@
 const nextConfig = {
   reactStrictMode: true,
   swcMinify: true,
+  experimental: {
+    optimizePackageImports: ['@mantine/core', '@mantine/hooks'],
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
When running the project, the console is filled with warnings from webpack suggesting that serializing big strings impacts performance. The `optimizePackageImports` option ensures that only modules actually being used will be loaded, rather than all modules that are exported from the packages. Similarly large libraries like `@mui/material` and `@tabler/icons-react` are "optimized" by Next.js by default. 

[Docs for `optimizePackageImports` can be found here](https://nextjs.org/docs/app/api-reference/next-config-js/optimizePackageImports)